### PR TITLE
add support for BRP072Cxx units

### DIFF
--- a/net.go
+++ b/net.go
@@ -36,6 +36,18 @@ func AddressOption(addr string) func(*DaikinNetwork) {
 	}
 }
 
+// AddressTokenOption specifies a specific address to query, and the API token to authenticate with
+func AddressTokenOption(addr string, token string) func(*DaikinNetwork) {
+	return func(d *DaikinNetwork) {
+		if addr != "" {
+			d.Devices = map[string]*Daikin{
+				addr: &Daikin{Address: addr, Token: token},
+			}
+			d.PollCount = 0
+		}
+	}
+}
+
 // NewNetwork returns a new DaikinNetwork, attached to the given interface.
 func NewNetwork(o ...Option) (*DaikinNetwork, error) {
 	dn := &DaikinNetwork{


### PR DESCRIPTION
These newer wifi addons from daikin require HTTPS and a token to be provided via a HTTP header.

I've also switch set_control_info from POST to GET - the POST wasn't working on my BRP072Cxx, but I'm not sure if this is a backwards compatible change.